### PR TITLE
Add additional features to the comport list

### DIFF
--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -18,6 +18,7 @@
 
     --accent-red:#FF6861;
     --accent-green:#63f076ef;
+    --accent-yellow:#efb710;
   }
 }
 

--- a/src/components/layout/Dashboard.js
+++ b/src/components/layout/Dashboard.js
@@ -19,7 +19,7 @@ import { useMockData } from '@/hooks/useMockData';
 
 export function Dashboard() {
     const { connected, setConnected, reset, setReset, checkStatusPing } = useBackendConnection();
-    const { boards, boardInfo, wirelessBoardInfo, setBoardInfo, connectToBoard, disconnectBoard } = useBoardConnection(reset);
+    const { boards, activeComPort, boardInfo, wirelessBoardInfo, setBoardInfo, connectToBoard, disconnectBoard } = useBoardConnection(reset);
     const { mockConnected, onMockConnected, onMockDisconnected } = useMockData(setBoardInfo);
     const sensorData = useSensorData(connected, mockConnected, checkStatusPing);
 
@@ -91,6 +91,7 @@ export function Dashboard() {
                     <SensorReadingWidget sensorData={sensorData} />
                     <BoardStatusWidget
                         boards={boards}
+                        activeComPort={activeComPort}
                         boardInfo={boardInfo}
                         wirelessBoardInfo={wirelessBoardInfo}
                         connected={connected}

--- a/src/components/widgets/BoardStatusWidget.js
+++ b/src/components/widgets/BoardStatusWidget.js
@@ -7,7 +7,7 @@ const COMBoard = ({ name, description, isConnected, onConnect, index }) => (
       <div className="flex flex-col justify-start items-start">
         <p className="font-bold h-full text-xl">{name}</p>
         {description && (
-          <p className="font-thin h-full text-sm p-0 m-0">{description}</p>
+          <p className="font-thin h-full text-sm p-0 m-0 opacity-80">{description}</p>
         )}
       </div>
       {isConnected ? (
@@ -25,8 +25,13 @@ const MockBoard = ({ onMockConnected }) => (
       onClick={onMockConnected}
       className="flex flex-row w-full font-medium px-4 py-6 rounded-3xl hover:bg-zinc-300/20 dark:hover:bg-base-200 "
     >
-      <p className="font-semibold h-full text-lg">MOCK FLIGHT</p>
-      <div className="size-4 ml-auto self-center rounded-full bg-yellow-500"></div>
+      <div className="flex flex-col items-start text-left">
+        <p className="font-bold text-xl">MOCK FC</p>
+        <p className="font-thin h-full text-sm p-0 m-0 opacity-80">
+          Simulates telemetry
+        </p>
+      </div>
+      <div className="size-4 ml-auto self-center rounded-full bg-accent-yellow"></div>
     </button>
   </div>
 );

--- a/src/components/widgets/BoardStatusWidget.js
+++ b/src/components/widgets/BoardStatusWidget.js
@@ -1,4 +1,4 @@
-const COMBoard = ({ name, description, onConnect, index }) => (
+const COMBoard = ({ name, description, isConnected, onConnect, index }) => (
   <div key={index} className="w-full justify-between rounded-xl">
     <button
       onClick={() => onConnect(name)}
@@ -10,7 +10,11 @@ const COMBoard = ({ name, description, onConnect, index }) => (
           <p className="font-thin h-full text-sm p-0 m-0">{description}</p>
         )}
       </div>
-      <div className="size-4 ml-auto self-center rounded-full bg-accent-red"></div>
+      {isConnected ? (
+        <div className="size-4 ml-auto self-center rounded-full bg-yellow-500"></div>
+      ) : (
+        <div className="size-4 ml-auto self-center rounded-full bg-accent-red"></div>
+      )}
     </button>
   </div>
 );
@@ -22,7 +26,7 @@ const MockBoard = ({ onMockConnected }) => (
       className="flex flex-row w-full font-medium px-4 py-6 rounded-3xl hover:bg-zinc-300/20 dark:hover:bg-base-200 "
     >
       <p className="font-semibold h-full text-lg">MOCK FLIGHT</p>
-      <div className="size-4 ml-auto self-center rounded-full bg-accent-red"></div>
+      <div className="size-4 ml-auto self-center rounded-full bg-yellow-500"></div>
     </button>
   </div>
 );
@@ -104,6 +108,7 @@ const WirelessBoardInformation = ({ wirelessBoardInfo }) => {
 // --- Parent component ---
 export const BoardStatusWidget = ({
   boards,
+  activeComPort,
   boardInfo,
   wirelessBoardInfo,
   connected,
@@ -133,6 +138,7 @@ export const BoardStatusWidget = ({
                     key={i}
                     name={port}
                     description={device_description}
+                    isConnected={port === activeComPort}
                     onConnect={onConnect}
                     index={i}
                   />

--- a/src/components/widgets/BoardStatusWidget.js
+++ b/src/components/widgets/BoardStatusWidget.js
@@ -1,10 +1,15 @@
-const COMBoard = ({ name, onConnect, index }) => (
+const COMBoard = ({ name, description, onConnect, index }) => (
   <div key={index} className="w-full justify-between rounded-xl">
     <button
       onClick={() => onConnect(name)}
       className="flex flex-row w-full font-medium px-4 py-6 rounded-3xl hover:opacity-80 hover:bg-zinc-300/20 dark:hover:bg-base-200"
     >
-      <p className="font-bold h-full text-xl">{name}</p>
+      <div className="flex flex-col justify-start items-start">
+        <p className="font-bold h-full text-xl">{name}</p>
+        {description && (
+          <p className="font-thin h-full text-sm p-0 m-0">{description}</p>
+        )}
+      </div>
       <div className="size-4 ml-auto self-center rounded-full bg-accent-red"></div>
     </button>
   </div>
@@ -123,7 +128,15 @@ export const BoardStatusWidget = ({
                 (
                 <div className="flex flex-col w-full">
                 <MockBoard onMockConnected={onMockConnected} />
-                {boards.map((port, i) => ( <COMBoard key={i} name={port} onConnect={onConnect} index={i} />))}
+                {boards.map(({ port, device_description }, i) => (
+                  <COMBoard
+                    key={i}
+                    name={port}
+                    description={device_description}
+                    onConnect={onConnect}
+                    index={i}
+                  />
+                ))}
                 </div>
                 )
             ) 

--- a/src/hooks/useBoardConnection.js
+++ b/src/hooks/useBoardConnection.js
@@ -15,7 +15,12 @@ export const useBoardConnection = (reset) => {
     useEffect(() => {
         api.getComPorts()
             .then(response => {
-                setBoards(response.data);
+                setBoards(
+                    Object.entries(response.data).map(([port, device_description]) => ({
+                        port,
+                        device_description,
+                    }))
+                );
             })
             .catch(error => {
                 console.error('Error fetching board data:', error);

--- a/src/hooks/useBoardConnection.js
+++ b/src/hooks/useBoardConnection.js
@@ -3,6 +3,7 @@ import { api } from '@/utils/api';
 
 export const useBoardConnection = (reset) => {
     const [boards, setBoards] = useState([]);
+    const [activeComPort, setActiveComPort] = useState(null);
     const [boardInfo, setBoardInfo] = useState({
         firmware: null,
         name: null,
@@ -13,14 +14,20 @@ export const useBoardConnection = (reset) => {
 
     // Fetch COM ports on reset
     useEffect(() => {
-        api.getComPorts()
-            .then(response => {
+        Promise.all([api.getComPorts(), api.getActiveComPort()])
+            .then(([portsResponse, activeResponse]) => {
                 setBoards(
-                    Object.entries(response.data).map(([port, device_description]) => ({
+                    Object.entries(portsResponse.data).map(([port, device_description]) => ({
                         port,
                         device_description,
                     }))
                 );
+
+                if (activeResponse.status === 204 || !activeResponse.data) {
+                    setActiveComPort(null);
+                } else {
+                    setActiveComPort(activeResponse.data);
+                }
             })
             .catch(error => {
                 console.error('Error fetching board data:', error);
@@ -112,6 +119,7 @@ export const useBoardConnection = (reset) => {
 
     return {
         boards,
+        activeComPort,
         boardInfo,
         wirelessBoardInfo,
         setBoardInfo,

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -14,6 +14,7 @@ export const api = {
         return axios.post(`${BASE_URL}/connect`, { comport:comport.toString() })
     },  
     getComPorts: () => axios.get(`${BASE_URL}/comports`),
+    getActiveComPort: () => axios.get(`${BASE_URL}/comports/active`),
     disconnectBoard: () => axios.get(`${BASE_URL}/disconnect`),
     getWirelessInfo: () => axios.get(`${BASE_URL}/wireless-stats`),
 

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -20,6 +20,7 @@ export default {
         "highlight": "var(--highlight)",
         "accent-red": "var(--accent-red)",
         "accent-green": "var(--accent-green)",
+        "accent-yellow": "var(--accent-yellow)",
        
       },
     },


### PR DESCRIPTION
#### Issue: N/A 

*An issue does not yet exist for tracking on the dashboard. However, as the API side changes the contract of the /comports endpoint, I wanted to make sure I provided a reference implementation for my own testing and so that I don't force you guys to update.*

## Description
Provides a reference implementation for the changes implemented to resolve https://github.com/SunDevilRocketry/SDEC-API/issues/16.

Child of: https://github.com/SunDevilRocketry/SDEC-API/pull/18

There are two features implemented here. One: the /comports route now returns a json with {port name, device description}. The comport list now reflects this. Two, a route at /comports/active has been added. This returns a string with the currently active comport to make it easier for multiple users to connect to the same device. This also carries a comport list update, where we now set the red dot to yellow if a device is able to be connected to.

Screenshot:
<img width="1916" height="908" alt="image" src="https://github.com/user-attachments/assets/d8be55a4-1db1-4dad-a436-a312df44923c" />


## Originator Checklist
- [ ] Title matches the form "GHI #<number> - <description of code change> [<Target Branch>]"
- [X] Target branch is correct
- [ ] Unit Tests have been posted in issue <if applicable,can be super simple like a screenshot>
- [ ] Issue has been linked to this PR
- [ ] Changes generate no new warnings
    - merge main into your branch to resolve conflicts before opening PR!

<br>

---

I like the new PR template! I'm a bit confused about the title field though, and I also think you might be misusing the term "unit tests"